### PR TITLE
Update rules for new library integrations

### DIFF
--- a/.cursor/rules/basic-design-rules.mdc
+++ b/.cursor/rules/basic-design-rules.mdc
@@ -6,12 +6,13 @@ alwaysApply: true
 更新日: 2025-08-24（JST）
 
 ## 1. 全体構成
-- **Front**: Next.js (App Router) + Tailwind + shadcn/ui
+- **Front**: Next.js (App Router) + Tailwind + shadcn/ui + zod + zustand
 - **API/Bot**: Go（gin）+ Starlark VM（go.starlark.net）
 - **Broker Adapter**: `infra/broker/moomoo`（Futu OpenD TCP/WS）
 - **Messaging**: Redis Streams（約定/サーキット/戦略ログ）
 - **DB**: MySQL 8（熱データ）+ Object Storage（ヒストリカル）
 - **Auth**: NextAuth + TOTP（Microsoft/Google Authenticator）
+- **Testing**: Bruno（エンドポイントテスト、日本語フォルダ構成）
 
 ## 2. コンポーネント
 - `apps/web`: 戦略センター、バックテスト、モニタ、設定、Kill。

--- a/.cursor/rules/nextjs-coding-standards.mdc
+++ b/.cursor/rules/nextjs-coding-standards.mdc
@@ -25,8 +25,9 @@ apps/web/
 │   └── layout/           # レイアウトコンポーネント
 ├── lib/                  # ユーティリティ・設定
 │   ├── utils.ts
-│   ├── validations.ts
+│   ├── validations.ts    # zod スキーマ
 │   ├── api.ts
+│   ├── store.ts          # zustand ストア
 │   └── constants.ts
 ├── hooks/                # カスタムフック
 ├── types/                # TypeScript型定義
@@ -227,7 +228,61 @@ export function useOrderForm() {
 }
 ```
 
-### 3.2 Zustand使用（複雑な状態管理）
+### 3.2 Zod使用（バリデーション）
+```typescript
+// lib/validations.ts
+import { z } from 'zod';
+
+// 注文フォームのバリデーションスキーマ
+export const orderFormSchema = z.object({
+  symbol: z.string()
+    .min(1, '銘柄コードは必須です')
+    .max(10, '銘柄コードは10文字以内で入力してください')
+    .regex(/^[A-Z]+$/, '銘柄コードは大文字のアルファベットで入力してください'),
+  side: z.enum(['buy', 'sell'], {
+    errorMap: () => ({ message: '取引方向を選択してください' })
+  }),
+  size: z.number()
+    .positive('数量は正の数で入力してください')
+    .int('数量は整数で入力してください'),
+  price: z.number()
+    .positive('価格は正の数で入力してください')
+    .min(0.01, '価格は0.01以上で入力してください'),
+  orderType: z.enum(['market', 'limit', 'stop', 'stop_limit'], {
+    errorMap: () => ({ message: '注文種別を選択してください' })
+  }),
+  timeInForce: z.enum(['day', 'gtc', 'ioc'], {
+    errorMap: () => ({ message: '有効期限を選択してください' })
+  }).default('day')
+});
+
+export type OrderFormData = z.infer<typeof orderFormSchema>;
+
+// 戦略パラメータのバリデーションスキーマ
+export const strategyParamsSchema = z.object({
+  name: z.string().min(1, '戦略名は必須です').max(100, '戦略名は100文字以内で入力してください'),
+  description: z.string().max(500, '説明は500文字以内で入力してください').optional(),
+  parameters: z.record(z.union([z.string(), z.number(), z.boolean()])),
+  riskSettings: z.object({
+    maxRiskPerTrade: z.number().min(0.001).max(0.1),
+    maxDailyDrawdown: z.number().min(0.001).max(0.1),
+    maxWeeklyDrawdown: z.number().min(0.001).max(0.2)
+  })
+});
+
+export type StrategyParams = z.infer<typeof strategyParamsSchema>;
+
+// バリデーション関数
+export function validateOrderForm(data: unknown): OrderFormData {
+  return orderFormSchema.parse(data);
+}
+
+export function validateStrategyParams(data: unknown): StrategyParams {
+  return strategyParamsSchema.parse(data);
+}
+```
+
+### 3.3 Zustand使用（複雑な状態管理）
 ```typescript
 // stores/orderStore.ts
 import { create } from 'zustand';

--- a/.cursor/rules/requirements-definition-rules.mdc
+++ b/.cursor/rules/requirements-definition-rules.mdc
@@ -69,9 +69,11 @@ alwaysApply: true
   - 通過後も **Live は最小株数**で段階的に検証。
 
 ### 5.5 UI/運用
+- **フロントエンド**: Next.js + shadcn/ui + zod（バリデーション）+ zustand（状態管理）
 - 戦略センター（テンプレ選択→編集→BT→Paper→Live）。
 - モニタ（PnL、DD、勝率、戦略ログ、サーキット通知履歴）。
 - **Kill スイッチ**：未約定キャンセル＋全ポジ成行クローズ＋Runner 停止。二重確認。
+- **エンドポイントテスト**: Bruno（日本語フォルダ構成、エンドポイント毎に.brunoファイル）
 
 ### 5.6 税務エクスポート
 - **TWS 形式**：`trade_id,symbol,open_time,close_time,side,quantity,open_price,close_price,realized_pnl,commission,dividend,tax_withheld,currency,strategy_id`。

--- a/.cursor/rules/testing-standards.mdc
+++ b/.cursor/rules/testing-standards.mdc
@@ -1,6 +1,88 @@
 # Testing Standards & Best Practices
 
-## 1. 単体テスト規約
+## 1. エンドポイントテスト規約（Bruno）
+
+### 1.1 Bruno設定
+```json
+// bruno.json
+{
+  "version": "1",
+  "name": "moon-bot-api",
+  "type": "collection"
+}
+```
+
+### 1.2 フォルダ構成
+```
+bruno/
+├── 戦略管理/
+│   ├── 戦略一覧取得.bruno
+│   ├── 戦略詳細取得.bruno
+│   ├── 戦略作成.bruno
+│   ├── 戦略編集.bruno
+│   └── 戦略削除.bruno
+├── 注文管理/
+│   ├── 注文一覧取得.bruno
+│   ├── 注文詳細取得.bruno
+│   ├── 注文作成.bruno
+│   ├── 注文編集.bruno
+│   └── 注文キャンセル.bruno
+├── バックテスト/
+│   ├── バックテスト一覧取得.bruno
+│   ├── バックテスト実行.bruno
+│   └── バックテスト結果取得.bruno
+├── 監視/
+│   ├── PnL取得.bruno
+│   ├── サーキット状態取得.bruno
+│   └── 戦略ログ取得.bruno
+└── エクスポート/
+    ├── 税務エクスポートTWS.bruno
+    └── 税務エクスポート日本.bruno
+```
+
+### 1.3 テストファイル例
+```bruno
+# 戦略一覧取得.bruno
+meta {
+  name: 戦略一覧取得
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/strategies
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+  
+  test("レスポンスが配列であること", function() {
+    expect(response.body).to.be.an('array');
+  });
+  
+  test("各戦略に必須フィールドが含まれていること", function() {
+    response.body.forEach(strategy => {
+      expect(strategy).to.have.property('id');
+      expect(strategy).to.have.property('name');
+      expect(strategy).to.have.property('status');
+    });
+  });
+}
+```
+
+## 2. 単体テスト規約
 
 ### 1.1 Go単体テスト
 ```go


### PR DESCRIPTION
Update project documentation to formally introduce `zod`, `zustand`, `bruno`, and `shadcn/ui` for validation, state management, endpoint testing, and UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e4dc907-42a6-449b-b088-86b9ebac2ba7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e4dc907-42a6-449b-b088-86b9ebac2ba7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

