### PR TITLE
Add Bruno tests for API endpoints

### DIFF
--- a/tests/bruno/environments/local.json
+++ b/tests/bruno/environments/local.json
@@ -1,6 +1,14 @@
 {
   "name": "local",
   "data": {
-    "baseUrl": "http://localhost:8080"
+    "baseUrl": "http://localhost:8080",
+    "authToken": "test-token",
+    "orderId": "1",
+    "tradeId": "1",
+    "strategyId": "1",
+    "strategyVersionId": "1",
+    "backtestId": "1",
+    "symbol": "AAPL",
+    "traceId": "1"
   }
 }

--- a/tests/bruno/バックテスト/バックテストキャンセル.bru
+++ b/tests/bruno/バックテスト/バックテストキャンセル.bru
@@ -1,0 +1,25 @@
+meta {
+  name: バックテストキャンセル
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/v1/backtests/{{backtestId}}/cancel
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/バックテスト/バックテスト一覧取得.bru
+++ b/tests/bruno/バックテスト/バックテスト一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: バックテスト一覧取得
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/backtests
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/バックテスト/バックテスト削除.bru
+++ b/tests/bruno/バックテスト/バックテスト削除.bru
@@ -1,0 +1,25 @@
+meta {
+  name: バックテスト削除
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/backtests/{{backtestId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または204であること", function() {
+    expect([200,204]).to.include(response.status);
+  });
+}

--- a/tests/bruno/バックテスト/バックテスト実行.bru
+++ b/tests/bruno/バックテスト/バックテスト実行.bru
@@ -1,0 +1,32 @@
+meta {
+  name: バックテスト実行
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/v1/backtests
+  body: json
+    {
+      "name": "サンプルバックテスト",
+      "strategy_id": "{{strategyId}}",
+      "symbols": ["{{symbol}}"],
+      "start_date": "2024-01-01",
+      "end_date": "2024-01-31"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが201であること", function() {
+    expect(response.status).to.equal(201);
+  });
+}

--- a/tests/bruno/バックテスト/バックテスト結果取得.bru
+++ b/tests/bruno/バックテスト/バックテスト結果取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: バックテスト結果取得
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/backtests/{{backtestId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/ユニバース/シンボル一括追加.bru
+++ b/tests/bruno/ユニバース/シンボル一括追加.bru
@@ -1,0 +1,35 @@
+meta {
+  name: シンボル一括追加
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/v1/universe/bulk
+  body: json
+    {
+      "symbols": [
+        {
+          "symbol": "{{symbol}}",
+          "exchange": "NASDAQ",
+          "asset_type": "stock",
+          "is_active": true
+        }
+      ]
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが201であること", function() {
+    expect(response.status).to.equal(201);
+  });
+}

--- a/tests/bruno/ユニバース/シンボル削除.bru
+++ b/tests/bruno/ユニバース/シンボル削除.bru
@@ -1,0 +1,25 @@
+meta {
+  name: シンボル削除
+  type: http
+  seq: 3
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/universe/{{symbol}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または204であること", function() {
+    expect([200,204]).to.include(response.status);
+  });
+}

--- a/tests/bruno/ユニバース/シンボル追加.bru
+++ b/tests/bruno/ユニバース/シンボル追加.bru
@@ -1,0 +1,31 @@
+meta {
+  name: シンボル追加
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/v1/universe
+  body: json
+    {
+      "symbol": "{{symbol}}",
+      "exchange": "NASDAQ",
+      "asset_type": "stock",
+      "is_active": true
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが201であること", function() {
+    expect(response.status).to.equal(201);
+  });
+}

--- a/tests/bruno/ユニバース/ユニバース一覧取得.bru
+++ b/tests/bruno/ユニバース/ユニバース一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: ユニバース一覧取得
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/universe
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/戦略管理/戦略バージョン一覧取得.bru
+++ b/tests/bruno/戦略管理/戦略バージョン一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 戦略バージョン一覧取得
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/v1/strategies/{{strategyId}}/versions
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/戦略管理/戦略バージョン作成.bru
+++ b/tests/bruno/戦略管理/戦略バージョン作成.bru
@@ -1,0 +1,28 @@
+meta {
+  name: 戦略バージョン作成
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/v1/strategies/{{strategyId}}/versions
+  body: json
+    {
+      "code": "package main\nfunc main(){}"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または201であること", function() {
+    expect([200,201]).to.include(response.status);
+  });
+}

--- a/tests/bruno/戦略管理/戦略一覧取得.bru
+++ b/tests/bruno/戦略管理/戦略一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 戦略一覧取得
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/strategies
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/戦略管理/戦略作成.bru
+++ b/tests/bruno/戦略管理/戦略作成.bru
@@ -1,0 +1,29 @@
+meta {
+  name: 戦略作成
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/v1/strategies
+  body: json
+    {
+      "name": "テスト戦略",
+      "description": "サンプル"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または201であること", function() {
+    expect([200,201]).to.include(response.status);
+  });
+}

--- a/tests/bruno/戦略管理/戦略削除.bru
+++ b/tests/bruno/戦略管理/戦略削除.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 戦略削除
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/strategies/{{strategyId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または204であること", function() {
+    expect([200,204]).to.include(response.status);
+  });
+}

--- a/tests/bruno/戦略管理/戦略編集.bru
+++ b/tests/bruno/戦略管理/戦略編集.bru
@@ -1,0 +1,28 @@
+meta {
+  name: 戦略編集
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/api/v1/strategies/{{strategyId}}
+  body: json
+    {
+      "name": "更新戦略"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/戦略管理/戦略詳細取得.bru
+++ b/tests/bruno/戦略管理/戦略詳細取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 戦略詳細取得
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/strategies/{{strategyId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/注文管理/取引一覧取得.bru
+++ b/tests/bruno/注文管理/取引一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 取引一覧取得
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/v1/trades
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/注文管理/注文キャンセル.bru
+++ b/tests/bruno/注文管理/注文キャンセル.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 注文キャンセル
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/orders/{{orderId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または204であること", function() {
+    expect([200,204]).to.include(response.status);
+  });
+}

--- a/tests/bruno/注文管理/注文一覧取得.bru
+++ b/tests/bruno/注文管理/注文一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 注文一覧取得
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/orders
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/注文管理/注文作成.bru
+++ b/tests/bruno/注文管理/注文作成.bru
@@ -1,0 +1,30 @@
+meta {
+  name: 注文作成
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/v1/orders
+  body: json
+    {
+      "symbol": "{{symbol}}",
+      "side": "buy",
+      "quantity": 1
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200または201であること", function() {
+    expect([200,201]).to.include(response.status);
+  });
+}

--- a/tests/bruno/注文管理/注文編集.bru
+++ b/tests/bruno/注文管理/注文編集.bru
@@ -1,0 +1,28 @@
+meta {
+  name: 注文編集
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/api/v1/orders/{{orderId}}
+  body: json
+    {
+      "quantity": 2
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/注文管理/注文詳細取得.bru
+++ b/tests/bruno/注文管理/注文詳細取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 注文詳細取得
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/orders/{{orderId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/シンボルトレース一覧取得.bru
+++ b/tests/bruno/監査/シンボルトレース一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: シンボルトレース一覧取得
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/v1/audit/traces/symbol/{{symbol}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/トレースエクスポート.bru
+++ b/tests/bruno/監査/トレースエクスポート.bru
@@ -1,0 +1,28 @@
+meta {
+  name: トレースエクスポート
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/api/v1/audit/traces/export
+  body: json
+    {
+      "symbol": "{{symbol}}"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/トレースチェーン取得.bru
+++ b/tests/bruno/監査/トレースチェーン取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: トレースチェーン取得
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/audit/traces/{{traceId}}/chain
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/トレース作成.bru
+++ b/tests/bruno/監査/トレース作成.bru
@@ -1,0 +1,34 @@
+meta {
+  name: トレース作成
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/audit/traces
+  body: json
+    {
+      "strategy_id": "{{strategyId}}",
+      "symbol": "{{symbol}}",
+      "side": "buy",
+      "quantity": 1,
+      "price": 1.0,
+      "order_id": "{{orderId}}",
+      "trade_id": "{{tradeId}}"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが201であること", function() {
+    expect(response.status).to.equal(201);
+  });
+}

--- a/tests/bruno/監査/トレース取得.bru
+++ b/tests/bruno/監査/トレース取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: トレース取得
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/audit/traces/{{traceId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/トレース検索.bru
+++ b/tests/bruno/監査/トレース検索.bru
@@ -1,0 +1,28 @@
+meta {
+  name: トレース検索
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/v1/audit/traces/search
+  body: json
+    {
+      "symbol": "{{symbol}}"
+    }
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/戦略トレース一覧取得.bru
+++ b/tests/bruno/監査/戦略トレース一覧取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 戦略トレース一覧取得
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/audit/traces/strategy/{{strategyId}}
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}

--- a/tests/bruno/監査/戦略トレース統計取得.bru
+++ b/tests/bruno/監査/戦略トレース統計取得.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 戦略トレース統計取得
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/v1/audit/traces/strategy/{{strategyId}}/statistics
+  body: none
+  auth: {
+    type: bearer
+    token: {{authToken}}
+  }
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+tests {
+  test("ステータスコードが200であること", function() {
+    expect(response.status).to.equal(200);
+  });
+}


### PR DESCRIPTION
## Summary
- add Bruno test definitions covering orders, strategies, backtests, universe, and audit traces
- expand local Bruno environment with variables for IDs and auth token

## Testing
- `make test` *(fails: missing go module davecgh/go-spew)*
- `go mod tidy` *(fails: network access to proxy.golang.org forbidden)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae021e82148322aa5bef8aec3add28